### PR TITLE
Fix class name in XML comment on constructor

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/CallInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/CallInfo.cs
@@ -28,7 +28,7 @@ namespace System.Dynamic
     public sealed class CallInfo
     {
         /// <summary>
-        /// Creates a new PositionalArgumentInfo.
+        /// Creates a new CallInfo that represents arguments in the dynamic binding process.
         /// </summary>
         /// <param name="argCount">The number of arguments.</param>
         /// <param name="argNames">The argument names.</param>


### PR DESCRIPTION
Name refers to non-existent type. A previous name during initial development perhaps?